### PR TITLE
Added sns configuration to send email for Critical alerts with severity HIGH

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ cd infra
 terraform init
 terraform apply  # Type 'yes'
 
+# (Optional) Enable email alerts for critical findings
+terraform apply -var="alert_email=you@example.com"
+# Then confirm the email you receive
+
 # Save API credentials
 terraform output -raw api_key > ../api_key.txt
 ```

--- a/infra/lambda.tf
+++ b/infra/lambda.tf
@@ -59,6 +59,13 @@ resource "aws_iam_role_policy" "scan_handler" {
           "dynamodb:BatchWriteItem"
         ]
         Resource = aws_dynamodb_table.findings.arn
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "sns:Publish"
+        ]
+        Resource = "${aws_sns_topic.critical_findings_alerts.arn}"
       }
     ]
   })
@@ -80,6 +87,7 @@ resource "aws_lambda_function" "scan_handler" {
       SNAPSHOTS_BUCKET = aws_s3_bucket.snapshots.id
       RULES_BUCKET     = aws_s3_bucket.rules.id
       FINDINGS_TABLE   = aws_dynamodb_table.findings.name
+      ALERTS_TOPIC_ARN = aws_sns_topic.critical_findings_alerts.arn
     }
   }
   

--- a/infra/sns.tf
+++ b/infra/sns.tf
@@ -1,0 +1,24 @@
+# sns.tf
+resource "aws_sns_topic" "critical_findings_alerts" {
+  name = "${local.name_prefix}-critical-findings"
+  tags = local.common_tags
+}
+
+# Optional: subscribe an email address (must be confirmed by the recipient)
+variable "alert_email" {
+  description = "Email to receive high-severity finding alerts via SNS"
+  type        = string
+  default     = ""
+}
+
+resource "aws_sns_topic_subscription" "critical_findings_email" {
+  count     = var.alert_email != "" ? 1 : 0
+  topic_arn = aws_sns_topic.critical_findings_alerts.arn
+  protocol  = "email"
+  endpoint  = var.alert_email
+}
+
+output "alerts_topic_arn" {
+  value = aws_sns_topic.critical_findings_alerts.arn
+}
+


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Critical findings alerts: Users can now optionally enable email notifications for high-severity findings discovered during scans by providing an email address during deployment.

* **Documentation**
  * Added setup instructions for enabling email alerts for critical security findings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->